### PR TITLE
fix get_demodulator_mode so it no longer causes off by one read line errors

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Perl extension GQRX::Remote.
 
+2.0.0	2019-01-19/23:45
+		- Fix get_demodulator_mode.
+
 1.0.1  Tue Mar 7, 2017
 	- Fix errors for disconnect warnings
         - Lower Perl version dependency to v5.6.2

--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-GQRX-Remote version 1.0.1
+GQRX-Remote
 =========================
 
 This module provides a Perl interface for the Gqrx remote control

--- a/Remote.pm
+++ b/Remote.pm
@@ -5,7 +5,7 @@ use IO::Socket::INET;
 use warnings;
 use strict;
 
-our $VERSION = '1.0.1';
+our $VERSION = '2.0.0';
 
 
 sub new {
@@ -134,6 +134,26 @@ sub command {
     return ($self->read_line(%opt));
 }
 
+sub command2 {
+    my $self = shift();
+    my $command = shift();
+    my (%opt) = @_;
+    my $buf;
+
+    if (! $self->{_connection}) {
+        $self->_set_error("Failed to send: Not connected");
+        return (undef);
+    }
+    elsif (! $self->{_connection}->connected()) {
+        $self->_set_error("Failed to send: Connection lost");
+        return (undef);
+    }
+
+    $self->{_connection}->send($command . "\n");
+
+    return ($self->read_line(%opt), $self->read_line(%opt));
+}
+
 
 sub set_frequency {
     my ($self, $frequency) = @_;
@@ -177,7 +197,7 @@ sub set_demodulator_mode {
 sub get_demodulator_mode {
     my ($self) = @_;
 
-    return ($self->command("m"));
+    return ($self->command2("m"));
 }
 
 
@@ -380,7 +400,7 @@ call will return C<undef>.
 =head2 DEMODULATOR MODE
 
     # To get the demodulator_mode:
-    $demodulator_mode = $remote->get_demodulator_mode();
+    my ($demodulator_mode, $width) = $remote->get_demodulator_mode();
 
     # To set the demodulator_mode:
     $remote->set_demodulator_mode('WFM');


### PR DESCRIPTION
The m command now returns two lines, the second is the width. This module expects the old behavior, which causes it to begin reporting incorrect data.

If get_demodulator_mode is called with out this patch it will return the demodulator used and leave the width in the buffer, which will then be returned when get_demodulator_mode or some other command is issued next.

This now returns a array, the first item being the demodulator and the second being the width.
